### PR TITLE
Made edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # lazy-jar
 
-an slack app for scheduling remote stand-ups and track participation
+Lazy-jar is a slack app for scheduling remote stand-ups and track participation.
 
 ## commands
 
 ### definitions
 
-* `name` is a unique identifier for a stand-up
-* `when` identifies when and how often an event should happen such as "everyday at 6pm", or "every workday at 4:30pm"
-* `time range` identifies a period of time such as "1 week", or "3 days"
+* `name` is a unique identifier for a stand-up.
+* `when` identifies the time and frequency of an event. E.g "everyday at 6pm", "every workday at 4:30pm".
+* `time range` identifies a period of time such as "1 week", or "3 days".
 
 ### slash commands
 
@@ -33,7 +33,7 @@ an slack app for scheduling remote stand-ups and track participation
   Nofity the bot when the team is on a break
   * e.g. "halt artris"
 * `lj resume [name]`
-  Nofity the bot when you want to restart the stand-ups
+  Nofity the bot when to restart the stand-ups
   * e.g. "resume artris"
 * `/lj status`
   Display info about the active stand-ups and member participation
@@ -42,10 +42,10 @@ an slack app for scheduling remote stand-ups and track participation
   * At least 8h before the stand-up
   * e.g. "I will skip artris for 2 weeks"
 * `/lj start notifying [username] for [name]`
-  Notify the bot that the hacker will start attending a stand-up again after a 'stop' or 'skip' command has been sent
+  Notify the bot the hacker will rejoin a stand-up again after a 'stop' or 'skip' command has been sent
   * e.g. "start notifying @grace for artris"
 * `/lj stop notifying [username] for [name]`
-  The hacker is on a break and will not be counted as part of a stand-up until the 'start' command is sent
+  The hacker is on a break and will be dismissed from the stand-up count until the 'start' command is sent
 
   * e.g. "stop notifying @grace for artris"
 


### PR DESCRIPTION
-Fixed the first sentence and made it a complete sentence.
-Under the "Definitions" section split up the run-on sentence into 2 sentences. 
-Changed the phrase "identifies when and how often an event should happen" to "identifies the time and frequency of an event". Removed filler words to make sentences concise and clear.
- Removed metadiscourse "such as" and added a new sentence  'E.g "everyday at 6pm", "every workday at 4:30pm"'.
- Removed unnecessary pronoun in the sentence describing `lj resume [name]` command.
-  Replaced words "start attending" with "rejoin" in the sentence describing `/lj start notifying [username] for [name]` command for better word choice and concision.
- For the `/lj stop notifying [username] for [name]` command, changed the phrase "will not be counted as part of" to "will be dismissed from" for better word choice and concision.
